### PR TITLE
Support parsing other names in DataGroup11

### DIFF
--- a/Sources/NFCPassportReader/DataGroups/DataGroup11.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup11.swift
@@ -21,6 +21,7 @@ public class DataGroup11 : DataGroup {
     public private(set) var proofOfCitizenship : String?
     public private(set) var tdNumbers : String?
     public private(set) var custodyInfo : String?
+    public private(set) var otherNames : [String]?
 
     public override var datagroupType: DataGroupId { .DG11 }
 
@@ -35,32 +36,117 @@ public class DataGroup11 : DataGroup {
         
         repeat {
             tag = try getNextTag()
-            let val = try String( bytes:getNextValue(), encoding:.utf8)
-            if tag == 0x5F0E {
-                fullName = val
-            } else if tag == 0x5F10 {
-                personalNumber = val
-            } else if tag == 0x5F11 {
-                placeOfBirth = val
-            } else if tag == 0x5F2B {
-                dateOfBirth = val
-            } else if tag == 0x5F42 {
-                address = val
-            } else if tag == 0x5F12 {
-                telephone = val
-            } else if tag == 0x5F13 {
-                profession = val
-            } else if tag == 0x5F14 {
-                title = val
-            } else if tag == 0x5F15 {
-                personalSummary = val
-            } else if tag == 0x5F16 {
-                proofOfCitizenship = val
-            } else if tag == 0x5F17 {
-                tdNumbers = val
-            } else if tag == 0x5F18 {
-                custodyInfo = val
+            let value = try getNextValue()
+
+            switch tag {
+            case 0x5F0E:
+                fullName = decodedString(from: value) ?? fullName
+            case 0x5F0F:
+                appendOtherName(from: value)
+            case 0x5F10:
+                personalNumber = decodedString(from: value) ?? personalNumber
+            case 0x5F11:
+                placeOfBirth = decodedString(from: value) ?? placeOfBirth
+            case 0x5F2B:
+                dateOfBirth = decodedString(from: value) ?? dateOfBirth
+            case 0x5F42:
+                address = decodedString(from: value) ?? address
+            case 0x5F12:
+                telephone = decodedString(from: value) ?? telephone
+            case 0x5F13:
+                profession = decodedString(from: value) ?? profession
+            case 0x5F14:
+                title = decodedString(from: value) ?? title
+            case 0x5F15:
+                personalSummary = decodedString(from: value) ?? personalSummary
+            case 0x5F16:
+                proofOfCitizenship = decodedString(from: value) ?? proofOfCitizenship
+            case 0x5F17:
+                tdNumbers = decodedString(from: value) ?? tdNumbers
+            case 0x5F18:
+                custodyInfo = decodedString(from: value) ?? custodyInfo
+            case 0xA0:
+                parseOtherNameList(value)
+            default:
+                continue
             }
         } while pos < data.count
+    }
+
+    private func decodedString(from value: [UInt8]) -> String? {
+        guard !value.isEmpty else { return nil }
+        return String(bytes: value, encoding: .utf8)
+    }
+
+    private func appendOtherName(from value: [UInt8]) {
+        guard let name = String(bytes: value, encoding: .utf8), !name.isEmpty else { return }
+        if otherNames != nil {
+            otherNames?.append(name)
+        } else {
+            otherNames = [name]
+        }
+    }
+
+    private func parseOtherNameList(_ value: [UInt8]) {
+        var offset = 0
+        var expectedNameCount: Int?
+        var parsedNames: [String] = []
+        var shouldStop = false
+
+        while offset < value.count && !shouldStop {
+            guard let innerTag = readTag(in: value, offset: &offset),
+                  let length = readLength(in: value, offset: &offset),
+                  offset + length <= value.count else { break }
+
+            let fieldValue = [UInt8](value[offset ..< offset + length])
+            offset += length
+
+            switch innerTag {
+            case 0x02:
+                expectedNameCount = fieldValue.reduce(0) { ($0 << 8) | Int($1) }
+            case 0x5F0F:
+                if let name = String(bytes: fieldValue, encoding: .utf8), !name.isEmpty {
+                    parsedNames.append(name)
+                    if let expected = expectedNameCount, parsedNames.count >= expected {
+                        shouldStop = true
+                    }
+                }
+            default:
+                continue
+            }
+        }
+
+        guard !parsedNames.isEmpty else { return }
+
+        if otherNames != nil {
+            otherNames?.append(contentsOf: parsedNames)
+        } else {
+            otherNames = parsedNames
+        }
+    }
+
+    private func readTag(in data: [UInt8], offset: inout Int) -> Int? {
+        guard offset < data.count else { return nil }
+
+        let current = data[offset]
+        if current & 0x1F == 0x1F {
+            guard offset + 1 < data.count else { return nil }
+            let tagBytes = [UInt8](data[offset...offset + 1])
+            offset += 2
+            return Int(binToHex(tagBytes))
+        } else {
+            offset += 1
+            return Int(current)
+        }
+    }
+
+    private func readLength(in data: [UInt8], offset: inout Int) -> Int? {
+        guard offset < data.count else { return nil }
+
+        let end = min(offset + 4, data.count)
+        let slice = [UInt8](data[offset..<end])
+        guard let (length, lengthOffset) = try? asn1Length(slice) else { return nil }
+        offset += lengthOffset
+        return length
     }
 }

--- a/Tests/NFCPassportReaderTests/DataGroupParsingTests.swift
+++ b/Tests/NFCPassportReaderTests/DataGroupParsingTests.swift
@@ -70,13 +70,13 @@ final class DataGroupParsingTests: XCTestCase {
     }
 
     func testDatagroup11Parsing() {
-        
+
         // This is a cut down version of the DG7 record. It contains everything up to the end of the image header - no actuall image data as its way too big to include here
         // I've also adjusted the record lengths accordingly
-        
+
         let dg11Val = hexRepToBin("6B305C065F0E5F2B5F115F0E0C546573743C3C5465737465725F2B0831393730313230315F110B4E6F727468616D70746F6E")
         let dgp = DataGroupParser()
-        
+
         XCTAssertNoThrow(try dgp.parseDG(data: dg11Val)) { dg in
             XCTAssertNotNil(dg)
             XCTAssertTrue( dg is DataGroup11 )
@@ -85,6 +85,22 @@ final class DataGroupParsingTests: XCTestCase {
             XCTAssertEqual(dg11.fullName, "Test<<Tester")
             XCTAssertEqual(dg11.dateOfBirth, "19701201")
             XCTAssertEqual(dg11.placeOfBirth, "Northampton")
+        }
+    }
+
+    func testDatagroup11ParsingOtherNames() {
+        let dg11Val = hexRepToBin("6b635c095f0e5f2b5f115f0fa05f0e0c546573743c3c5465737465725f2b0831393730313230315f110b4e6f727468616d70746f6e5f0f0a416c6961733c3c4f6e65a0210201025f0f0c4f746865723c3c4e616d65315f0f0c4f746865723c3c4e616d6532")
+        let dgp = DataGroupParser()
+
+        XCTAssertNoThrow(try dgp.parseDG(data: dg11Val)) { dg in
+            XCTAssertNotNil(dg)
+            XCTAssertTrue(dg is DataGroup11)
+
+            let dg11 = dg as! DataGroup11
+            XCTAssertEqual(dg11.fullName, "Test<<Tester")
+            XCTAssertEqual(dg11.dateOfBirth, "19701201")
+            XCTAssertEqual(dg11.placeOfBirth, "Northampton")
+            XCTAssertEqual(dg11.otherNames, ["Alias<<One", "Other<<Name1", "Other<<Name2"])
         }
     }
 


### PR DESCRIPTION
## Summary
- add a read-only `otherNames` collection to `DataGroup11`
- decode tag 0x5F0F entries, including nested name lists, when parsing DG11
- refactor DG11 parsing to share UTF-8 decoding helpers

## Testing
- swift test *(fails: no such module 'OSLog' on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ae34ed308324b54053bd1e651105